### PR TITLE
Fix: Elevation of privilege vulnerability in kernel file system

### DIFF
--- a/fs/f2fs/data.c
+++ b/fs/f2fs/data.c
@@ -387,6 +387,15 @@ int f2fs_readpage(struct f2fs_sb_info *sbi, struct page *page,
 	return 0;
 }
 
+static int get_data_block_ro_bmap(struct inode *inode, sector_t iblock,
+			struct buffer_head *bh_result, int create)
+{
+	/* Block number less than F2FS MAX BLOCKS */
+	if (unlikely(iblock >= max_file_size(0)))
+		return -EFBIG;
+	return get_data_block_ro(inode, iblock, bh_result, create, false);
+}
+
 /*
  * This function should be used by the data read flow only where it
  * does not check the "create" flag that indicates block allocation.
@@ -731,7 +740,7 @@ static int f2fs_set_data_page_dirty(struct page *page)
 
 static sector_t f2fs_bmap(struct address_space *mapping, sector_t block)
 {
-	return generic_block_bmap(mapping, block, get_data_block_ro);
+	return generic_block_bmap(mapping, block, get_data_block_ro_bmap);
 }
 
 const struct address_space_operations f2fs_dblock_aops = {

--- a/fs/f2fs/f2fs.h
+++ b/fs/f2fs/f2fs.h
@@ -928,6 +928,7 @@ static inline int f2fs_add_link(struct dentry *dentry, struct inode *inode)
 /*
  * super.c
  */
+loff_t max_file_size(unsigned bits);
 int f2fs_sync_fs(struct super_block *, int);
 extern __printf(3, 4)
 void f2fs_msg(struct super_block *, const char *, const char *, ...);

--- a/fs/f2fs/super.c
+++ b/fs/f2fs/super.c
@@ -376,7 +376,7 @@ static int parse_options(struct super_block *sb, struct f2fs_sb_info *sbi,
 	return 0;
 }
 
-static loff_t max_file_size(unsigned bits)
+loff_t max_file_size(unsigned bits)
 {
 	loff_t result = ADDRS_PER_INODE;
 	loff_t leaf_count = ADDRS_PER_BLOCK;


### PR DESCRIPTION
An elevation of privilege vulnerability in the kernel file system could enable
a local malicious application to execute arbitrary code within the context of
the kernel. This issue is rated as High because it first requires compromising
a privileged process.

CVE            References     Severity
CVE-2016-3802  A-28271368     High

Issue: CYNGNOS-3281

Change-Id: I313dd754911251e7f01a0eb3710ee2565dcc4d1f
